### PR TITLE
Modernize route mapper layout and add edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # SnowCap Route Mapper
 
-Static front-end route visualization for the SnowCap network. The site is modernized with a responsive layout, password gate, and interactive Google Map showing 13 predefined routes. Everything runs client-side, making it ideal for GitHub Pages hosting.
+A modernized, client-side route visualization for the SnowCap delivery network. The application runs entirely in the browser (ideal for GitHub Pages) and ships with thirteen pre-geocoded routes so the map renders instantly.
 
 ## Features
 
-- Password lock screen with casual client-side protection using `sessionStorage` to remember successful unlocks for the session.
-- Responsive split layout with sidebar controls, results panel, and Google Map view.
-- Sidebar slots for organization and partner logos (replace SVG placeholders in `assets/`).
-- Route list with color badges that match polylines on the map. Toggle between viewing all routes or focusing on a single selection.
-- Address search powered by the Google Maps Geocoding service. The nearest route is highlighted with a dashed connector and distance summary using Turf.js geometry helpers.
-- Optional light/dark theme toggle that swaps CSS variable values instantly on the client.
+- Password lock screen with branded messaging. Successful unlocks are cached with `sessionStorage` for the current tab.
+- Responsive two-pane layout with dedicated areas for partner logos, route controls, and Google Maps.
+- Sidebar route directory featuring color swatches that match on-map polylines, plus real-time totals for routes and stops.
+- “Show All Routes” and single-route focus modes with smooth camera fitting.
+- Address search powered by the Google Maps Geocoding service. Turf.js calculates the nearest route and draws a dashed connector with distance in miles.
+- Edit Route Mode: drag-and-drop existing stops, click the map to append new stops (with optional labels), remove stops by clicking markers, then save to `localStorage` or cancel to revert.
+- Persistent storage of route edits using `localStorage` under the `savedRoutes` key.
 
 ## Getting started
 
-1. Replace `YOUR_API_KEY` in `index.html` with a valid Google Maps JavaScript API key. Make sure the Maps JavaScript API and Geocoding API are enabled for that key.
-2. (Optional) Update the password in `js/config.js` by editing `PUBLIC_PASSWORD`.
-3. Open `index.html` directly in a browser or deploy the project to GitHub Pages.
+1. Replace `YOUR_API_KEY` in `index.html` with a valid Google Maps JavaScript API key that has the Maps JavaScript API enabled.
+2. (Optional) Update the password in `js/config.js` by changing `PUBLIC_PASSWORD`.
+3. Open `index.html` locally in a browser or deploy the project as-is to GitHub Pages.
 
-No build step or server is required. All dependencies load from public CDNs when the page runs.
+All dependencies load from public CDNs, and no build tooling or server is required.
 
 ## File structure
 
@@ -41,15 +42,9 @@ No build step or server is required. All dependencies load from public CDNs when
 
 ## Development notes
 
-- All scripts are loaded with `defer` so that HTML parsing is never blocked.
-- The Google Map initializes only after the password gate unlocks, keeping the splash screen lightweight.
-- Turf.js is used for closest-route calculations (`nearestPointOnLine` and `distance`).
-- Styling uses CSS custom properties and a mobile-first layout. Update the palette or spacing scale in `css/styles.css` as needed.
-
-## Customization checklist
-
-- Swap SVG logos in `assets/` with brand assets and update anchor links in `index.html`.
-- Edit `js/routes.js` to adjust coordinates, names, and colors for each route.
-- Tune map defaults or add additional UI in `js/app.js`.
+- Routes are preloaded from `js/routes.js`, and any edits are merged from `localStorage` on startup.
+- Google Maps objects initialize only after the password gate dispatches the `app:unlock` event.
+- `Utils` centralizes helpers for converting coordinate arrays, building DOM nodes, and animating route list focus.
+- Styling relies on CSS custom properties and mobile-first layout rules in `css/styles.css`.
 
 Happy mapping!

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,75 +1,26 @@
 :root {
   color-scheme: light;
-  --bg: #f5f7fb;
-  --panel: #ffffff;
-  --text: #1f2933;
-  --muted: #6b7280;
-  --accent: #2563eb;
-  --accent-contrast: #ffffff;
-  --ok: #059669;
-  --warn: #dc2626;
-  --lock-gradient: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(15, 23, 42, 0.7));
-  --shadow-strong: rgba(15, 23, 42, 0.2);
-  --shadow-medium: rgba(15, 23, 42, 0.15);
-  --shadow-soft: rgba(15, 23, 42, 0.1);
-  --shadow-light: rgba(15, 23, 42, 0.08);
-  --accent-glow: rgba(37, 99, 235, 0.25);
-  --accent-surface-0: rgba(37, 99, 235, 0.05);
-  --accent-surface-1: rgba(37, 99, 235, 0.06);
-  --accent-surface-2: rgba(37, 99, 235, 0.12);
-  --accent-surface-3: rgba(37, 99, 235, 0.18);
-  --accent-surface-4: rgba(37, 99, 235, 0.2);
-  --accent-clear: rgba(37, 99, 235, 0);
-  --accent-outline: rgba(37, 99, 235, 0.35);
-  --accent-outline-strong: rgba(37, 99, 235, 0.4);
-  --accent-border: rgba(37, 99, 235, 0.3);
-  --border-soft: rgba(15, 23, 42, 0.15);
-  --border-softer: rgba(15, 23, 42, 0.1);
-  --border-softest: rgba(15, 23, 42, 0.08);
-  --border-strong: rgba(15, 23, 42, 0.25);
-  --focus-glow: rgba(99, 102, 241, 0.5);
-  --surface-translucent: rgba(255, 255, 255, 0.9);
-  --scrollbar-thumb: rgba(37, 99, 235, 0.3);
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.5rem;
-  --space-6: 2.5rem;
-}
-
-body[data-theme="dark"] {
-  color-scheme: dark;
-  --bg: #0f172a;
-  --panel: #111c34;
-  --text: #f8fafc;
-  --muted: #cbd5f5;
-  --accent: #60a5fa;
-  --accent-contrast: #0f172a;
-  --ok: #22c55e;
-  --warn: #f87171;
-  --lock-gradient: linear-gradient(135deg, rgba(96, 165, 250, 0.18), rgba(15, 23, 42, 0.9));
-  --shadow-strong: rgba(15, 23, 42, 0.65);
-  --shadow-medium: rgba(15, 23, 42, 0.5);
-  --shadow-soft: rgba(15, 23, 42, 0.35);
-  --shadow-light: rgba(15, 23, 42, 0.25);
-  --accent-glow: rgba(96, 165, 250, 0.35);
-  --accent-surface-0: rgba(96, 165, 250, 0.1);
-  --accent-surface-1: rgba(96, 165, 250, 0.08);
-  --accent-surface-2: rgba(96, 165, 250, 0.16);
-  --accent-surface-3: rgba(96, 165, 250, 0.22);
-  --accent-surface-4: rgba(96, 165, 250, 0.28);
-  --accent-clear: rgba(96, 165, 250, 0);
-  --accent-outline: rgba(96, 165, 250, 0.45);
-  --accent-outline-strong: rgba(96, 165, 250, 0.6);
-  --accent-border: rgba(96, 165, 250, 0.4);
-  --border-soft: rgba(148, 163, 184, 0.35);
-  --border-softer: rgba(148, 163, 184, 0.25);
-  --border-softest: rgba(148, 163, 184, 0.2);
-  --border-strong: rgba(148, 163, 184, 0.45);
-  --focus-glow: rgba(96, 165, 250, 0.55);
-  --surface-translucent: rgba(15, 23, 42, 0.8);
-  --scrollbar-thumb: rgba(96, 165, 250, 0.45);
+  --color-bg: #f4f6fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f3fa;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-border-strong: rgba(15, 23, 42, 0.18);
+  --color-text: #0f172a;
+  --color-muted: #64748b;
+  --color-accent: #2563eb;
+  --color-accent-contrast: #ffffff;
+  --color-warn: #dc2626;
+  --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.14);
+  --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
@@ -79,10 +30,10 @@ body[data-theme="dark"] {
 body {
   margin: 0;
   min-height: 100vh;
-  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  line-height: 1.6;
+  background: linear-gradient(180deg, rgba(226, 232, 240, 0.6), rgba(148, 163, 184, 0.2));
+  color: var(--color-text);
+  font-family: inherit;
+  line-height: 1.5;
 }
 
 img {
@@ -90,19 +41,23 @@ img {
   display: block;
 }
 
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
 a {
   color: inherit;
   text-decoration: none;
 }
 
-button {
-  font-family: inherit;
-}
-
 .noscript {
-  background: var(--warn);
-  color: var(--accent-contrast);
-  padding: var(--space-4);
+  background: var(--color-warn);
+  color: var(--color-accent-contrast);
+  padding: var(--space-sm);
   text-align: center;
 }
 
@@ -112,9 +67,9 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--lock-gradient);
-  padding: var(--space-5);
-  z-index: 1000;
+  padding: var(--space-xl);
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.4), rgba(15, 23, 42, 0.85));
+  z-index: 10;
 }
 
 .lock-screen.is-hidden {
@@ -122,24 +77,33 @@ button {
 }
 
 .lock-card {
-  background: var(--panel);
-  color: var(--text);
-  padding: var(--space-6);
-  max-width: 380px;
+  max-width: 420px;
   width: 100%;
-  border-radius: 18px;
-  box-shadow: 0 24px 60px var(--shadow-strong);
+  padding: var(--space-xl);
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  box-shadow: var(--shadow-lg);
+  display: grid;
+  gap: var(--space-lg);
   text-align: center;
 }
 
 .lock-card__logo {
-  margin: 0 auto var(--space-4);
   width: 120px;
+  margin: 0 auto;
+  filter: drop-shadow(0 8px 20px rgba(15, 23, 42, 0.4));
+}
+
+.lock-card__subtitle {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(226, 232, 240, 0.8);
 }
 
 .lock-form {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-sm);
   text-align: left;
 }
 
@@ -147,265 +111,244 @@ button {
   font-weight: 600;
 }
 
-.lock-form input {
-  padding: var(--space-3);
-  border-radius: 10px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-translucent);
-  color: var(--text);
+.lock-form input[type="password"] {
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(248, 250, 252, 0.4);
+  background: rgba(15, 23, 42, 0.35);
+  color: inherit;
 }
 
-.lock-form input:focus-visible {
-  outline: 3px solid var(--accent);
+.lock-form input[type="password"]:focus-visible {
+  outline: 3px solid rgba(148, 197, 255, 0.6);
   outline-offset: 2px;
 }
 
 .lock-form__note {
+  margin: var(--space-xs) 0 0;
   font-size: 0.85rem;
-  color: var(--muted);
-  text-align: center;
+  color: rgba(226, 232, 240, 0.7);
 }
 
 .lock-form__error {
   min-height: 1.2em;
-  color: var(--warn);
   font-weight: 600;
-  text-align: center;
-}
-
-.btn {
-  cursor: pointer;
-  border: none;
-  padding: var(--space-3) var(--space-4);
-  border-radius: 999px;
-  background: var(--accent);
-  color: var(--accent-contrast);
-  font-weight: 600;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 18px var(--accent-glow);
-}
-
-.btn:active {
-  transform: translateY(0);
-  box-shadow: none;
-}
-
-.btn:focus-visible {
-  outline: 3px solid var(--focus-glow);
-  outline-offset: 3px;
-}
-
-.btn-secondary {
-  background: var(--accent-surface-2);
-  color: var(--text);
-  border: 1px solid var(--accent-border);
-  box-shadow: none;
-}
-
-.btn-secondary:hover {
-  background: var(--accent-surface-4);
-}
-
-.btn-tertiary {
-  background: transparent;
-  color: var(--muted);
-  border: 1px solid var(--border-softer);
-  box-shadow: none;
-}
-
-.btn-tertiary:hover {
-  color: var(--text);
-  border-color: var(--border-strong);
+  color: #fca5a5;
 }
 
 .app-shell {
-  display: none;
-  min-height: 100vh;
+  display: flex;
   flex-direction: column;
+  min-height: 100vh;
+  opacity: 0;
+  transition: opacity 200ms ease;
 }
 
 .app-shell.is-active {
-  display: flex;
+  opacity: 1;
 }
 
 .sidebar {
-  background: var(--panel);
+  background: var(--color-surface);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow-lg);
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  padding: var(--space-5) var(--space-4) var(--space-6);
-  box-shadow: 0 8px 30px var(--shadow-medium);
-  z-index: 10;
+  gap: var(--space-lg);
+  padding: var(--space-lg);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+  z-index: 2;
 }
 
 .sidebar__header {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-3);
+  gap: var(--space-sm);
+}
+
+.sidebar__brand {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
 }
 
-.logo-slot {
-  display: grid;
-  place-items: center;
-  background: var(--accent-surface-1);
-  border-radius: 14px;
-  padding: var(--space-2);
-  min-height: 56px;
-  color: var(--muted);
-  font-weight: 600;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.sidebar__brand-logo {
+  width: 140px;
 }
 
-.logo-slot.main-logo {
-  background: transparent;
-  padding: 0;
+.sidebar__brand-partners {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
-.logo-slot img {
-  width: 100%;
-  max-width: 120px;
+.sidebar__brand-partners img {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  padding: var(--space-xs);
+}
+
+.sidebar__tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
 }
 
 .sidebar__controls {
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-sm);
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
 .section-title {
-  margin: 0 0 var(--space-3);
-  font-size: 1rem;
-  letter-spacing: 0.05em;
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
-  color: var(--muted);
+}
+
+.section-caption {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.sidebar__routes {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 200px;
+  max-height: 320px;
 }
 
 .route-list {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  max-height: 260px;
+  gap: var(--space-xs);
   overflow-y: auto;
-  padding-right: var(--space-2);
 }
 
 .route-item {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--space-3);
-  background: var(--accent-surface-1);
-  border-radius: 14px;
-  padding: var(--space-3);
-  border: 1px solid transparent;
-  transition: background 0.2s ease, border 0.2s ease;
-}
-
-.route-item[aria-pressed="true"],
-.route-item.is-selected {
-  border-color: var(--accent-outline-strong);
-  background: var(--accent-surface-2);
-  font-weight: 600;
-}
-
-.route-item:hover {
-  background: var(--accent-surface-3);
+  gap: var(--space-sm);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
 }
 
 .route-item:focus-visible {
-  outline: 3px solid var(--accent-outline);
-  outline-offset: 3px;
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.route-item:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.route-item.is-selected {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+  background: #eef3ff;
 }
 
 .route-item__label {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-sm);
+  text-align: left;
 }
 
 .route-item__swatch {
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  border: 2px solid var(--border-softest);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(15, 23, 42, 0.12);
 }
 
 .route-item__name {
-  margin: 0;
+  font-weight: 600;
+  display: block;
 }
 
 .route-item__hint {
   font-size: 0.75rem;
-  letter-spacing: 0.08em;
+  color: var(--color-muted);
   text-transform: uppercase;
-  color: var(--muted);
+  letter-spacing: 0.08em;
 }
 
-.highlight-pulse {
-  animation: pulse 1.2s ease;
+.edit-panel {
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  background: #e7f0ff;
+  box-shadow: inset 0 1px 0 rgba(37, 99, 235, 0.15);
+  display: grid;
+  gap: var(--space-sm);
 }
 
-@keyframes pulse {
-  0% {
-    box-shadow: 0 0 0 0 var(--accent-glow);
-  }
-  100% {
-    box-shadow: 0 0 0 20px var(--accent-clear);
-  }
+.edit-panel[hidden] {
+  display: none;
+}
+
+.edit-panel__instructions {
+  margin: 0;
+  color: #1e3a8a;
+  font-size: 0.9rem;
+}
+
+.edit-panel__actions {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
 }
 
 .sidebar__results {
-  background: var(--accent-surface-0);
-  border-radius: 18px;
-  padding: var(--space-4);
-  min-height: 120px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm);
+  background: var(--color-surface-alt);
+  display: grid;
+  gap: var(--space-xs);
 }
 
 .result-text {
   margin: 0;
-  color: var(--text);
 }
 
 .result-meta {
-  margin: var(--space-2) 0 0;
-  color: var(--muted);
-  font-size: 0.9rem;
-}
-
-.sidebar__partners {
-  display: flex;
-  gap: var(--space-3);
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-3);
-  background: var(--accent-surface-1);
-  border-radius: 14px;
-}
-
-.sidebar__partners img {
-  height: 32px;
-  width: auto;
-  filter: saturate(0.9);
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .sidebar__form {
-  margin-top: auto;
   display: grid;
-  gap: var(--space-3);
-  position: sticky;
-  bottom: 0;
-  background: var(--panel);
-  padding-top: var(--space-4);
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--color-border);
+  background: var(--color-surface-alt);
 }
 
 .sidebar__form label {
@@ -414,21 +357,82 @@ button {
 
 .form-row {
   display: flex;
-  gap: var(--space-3);
+  gap: var(--space-sm);
 }
 
-.form-row input {
+.form-row input[type="text"] {
   flex: 1;
-  padding: var(--space-3);
-  border-radius: 14px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-translucent);
-  color: var(--text);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
-.form-row input:focus-visible {
-  outline: 3px solid var(--accent);
+.form-row input[type="text"]:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
   outline-offset: 2px;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+}
+
+.sidebar__footer img {
+  width: 72px;
+  height: 32px;
+  object-fit: contain;
+  filter: saturate(0.85);
+}
+
+.btn {
+  border: none;
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  padding: 0.65rem 1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn-secondary {
+  background: #1e3a8a;
+}
+
+.btn-tertiary {
+  background: #0f172a;
+}
+
+.btn-save {
+  background: #059669;
+}
+
+.btn-cancel {
+  background: #ef4444;
 }
 
 .map {
@@ -436,15 +440,48 @@ button {
   min-height: 320px;
 }
 
-@media (min-width: 768px) {
+body.edit-mode .sidebar {
+  border: 2px solid rgba(37, 99, 235, 0.3);
+}
+
+body.edit-mode .route-item.is-selected {
+  background: #e0f2fe;
+  border-color: #0284c7;
+  box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.18);
+}
+
+body.edit-mode #map::after {
+  content: "Edit mode active";
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.app-shell,
+.sidebar,
+.map {
+  position: relative;
+}
+
+@media (min-width: 992px) {
   .app-shell {
     flex-direction: row;
   }
 
   .sidebar {
-    width: clamp(280px, 32vw, 320px);
+    width: 360px;
     min-height: 100vh;
-    position: relative;
+    border-radius: 0;
   }
 
   .map {
@@ -457,7 +494,7 @@ button {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-thumb);
+  background: rgba(15, 23, 42, 0.25);
   border-radius: 999px;
 }
 

--- a/index.html
+++ b/index.html
@@ -10,16 +10,17 @@
   <noscript>
     <div class="noscript">This application requires JavaScript to run. Please enable JavaScript in your browser.</div>
   </noscript>
+
   <div id="lock" class="lock-screen" role="dialog" aria-modal="true" aria-labelledby="lock-title" aria-describedby="lock-subtitle">
     <div class="lock-card">
-      <img src="./assets/logo-main.svg" alt="SnowCap Route Mapper logo" class="lock-card__logo" />
+      <img src="./assets/logo-main.svg" alt="SnowCap main logo" class="lock-card__logo" />
       <h1 id="lock-title">SnowCap Route Mapper</h1>
-      <p id="lock-subtitle">Enter the access password to continue.</p>
+      <p id="lock-subtitle" class="lock-card__subtitle">Protected delivery intelligence for partners and drivers.</p>
       <form id="lock-form" class="lock-form" novalidate>
-        <label for="lock-password">Password</label>
+        <label for="lock-password">Access password</label>
         <input type="password" id="lock-password" name="password" autocomplete="current-password" required />
-        <button type="submit" class="btn">Continue</button>
-        <p class="lock-form__note">This lock is client side only.</p>
+        <button type="submit" class="btn">Enter</button>
+        <p class="lock-form__note">Client-side lock for demonstration only.</p>
         <p id="lock-error" class="lock-form__error" role="status" aria-live="polite"></p>
       </form>
     </div>
@@ -27,34 +28,47 @@
 
   <div id="app" class="app-shell" aria-hidden="true">
     <aside id="sidebar" class="sidebar" aria-label="Route controls">
-      <header class="sidebar__header" aria-label="Organization logos">
-        <a href="#" class="logo-slot main-logo" aria-label="Primary organization link">
-          <img src="./assets/logo-main.svg" alt="Primary logo" />
-        </a>
-        <a href="#" class="logo-slot" aria-label="Secondary organization link placeholder">
-          <span>Logo</span>
-        </a>
-        <a href="#" class="logo-slot" aria-label="Tertiary organization link placeholder">
-          <span>Logo</span>
-        </a>
+      <header class="sidebar__header" aria-label="Partner logos">
+        <div class="sidebar__brand">
+          <img src="./assets/logo-main.svg" alt="SnowCap logo" class="sidebar__brand-logo" />
+          <div class="sidebar__brand-partners">
+            <img src="./assets/logo-partner-1.svg" alt="Partner 1 logo" />
+            <img src="./assets/logo-partner-2.svg" alt="Partner 2 logo" />
+          </div>
+        </div>
+        <p class="sidebar__tagline">Coordinating deliveries across Portland &amp; Gresham.</p>
       </header>
+
       <div class="sidebar__controls" id="sidebar-controls">
-        <button type="button" class="btn" id="show-all">Show all routes</button>
-        <button type="button" class="btn btn-secondary" id="clear-address">Clear address</button>
-        <button type="button" class="btn btn-tertiary" id="theme-toggle" aria-pressed="false">Toggle theme</button>
+        <button type="button" class="btn" id="show-all">Show All Routes</button>
+        <button type="button" class="btn btn-secondary" id="edit-route" aria-pressed="false">Edit Route</button>
+        <button type="button" class="btn btn-tertiary" id="clear-address">Clear Address</button>
       </div>
-      <section class="sidebar__routes" aria-labelledby="routes-heading">
-        <h2 class="section-title" id="routes-heading">Routes</h2>
-        <ul id="route-list" class="route-list" aria-live="polite"></ul>
+
+      <section id="edit-panel" class="edit-panel" hidden aria-live="polite">
+        <h2 class="section-title">Edit mode</h2>
+        <p class="edit-panel__instructions">
+          Select a route to drag stops, click the map to add new stops, or tap an existing stop to delete it. Save to persist or cancel to revert.
+        </p>
+        <div class="edit-panel__actions">
+          <button type="button" class="btn btn-save" id="save-route" disabled>Save Changes</button>
+          <button type="button" class="btn btn-cancel" id="cancel-edit">Cancel</button>
+        </div>
       </section>
+
+      <section class="sidebar__routes" aria-labelledby="routes-heading">
+        <div class="section-heading">
+          <h2 class="section-title" id="routes-heading">Routes</h2>
+          <p class="section-caption" id="route-summary" aria-live="polite"></p>
+        </div>
+        <ul id="route-list" class="route-list" aria-live="polite" aria-describedby="routes-heading"></ul>
+      </section>
+
       <section class="sidebar__results" id="results-panel" aria-live="polite" aria-atomic="true">
         <h2 class="section-title">Closest route</h2>
         <p class="result-text">Search for an address to see the nearest route.</p>
       </section>
-      <footer class="sidebar__partners" aria-label="Partner logos">
-        <img src="./assets/logo-partner-1.svg" alt="Partner 1 logo" />
-        <img src="./assets/logo-partner-2.svg" alt="Partner 2 logo" />
-      </footer>
+
       <form id="address-form" class="sidebar__form" autocomplete="off">
         <label for="address-input">Find the closest route</label>
         <div class="form-row">
@@ -62,6 +76,11 @@
           <button type="submit" class="btn">Find</button>
         </div>
       </form>
+
+      <footer class="sidebar__footer" aria-label="Supporting partners">
+        <img src="./assets/logo-partner-1.svg" alt="Partner 1 logo" />
+        <img src="./assets/logo-partner-2.svg" alt="Partner 2 logo" />
+      </footer>
     </aside>
     <main id="map" class="map" role="application" aria-label="Route map"></main>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -1,27 +1,42 @@
 (function () {
-  const MAP_CENTER = { lat: 30.2672, lng: -97.7431 };
-  const DEFAULT_ZOOM = 11;
-  const THEME_KEY = "scrm-theme";
+  const MAP_CENTER = { lat: 45.503, lng: -122.48 };
+  const DEFAULT_ZOOM = 12;
+  const STORAGE_KEY = "savedRoutes";
 
   let initialized = false;
   let map;
   let geocoder;
+  let routes = [];
   let allBounds;
-  let marker = null;
-  let connectorLine = null;
-  let mode = "all";
-  let selectedRouteId = null;
 
   const routePolylines = new Map();
   const routeBounds = new Map();
-  const routeButtons = new Map();
   const routeLineStrings = new Map();
+  const routeButtons = new Map();
 
   let routeListEl;
   let resultsPanelEl;
-  let resultsTextEl;
   let addressInputEl;
-  let themeToggleEl;
+  let routeSummaryEl;
+  let showAllBtn;
+  let editModeBtn;
+  let clearAddressBtn;
+  let editPanelEl;
+  let saveRouteBtn;
+  let cancelEditBtn;
+
+  let mode = "all";
+  let selectedRouteId = null;
+
+  let marker = null;
+  let connectorLine = null;
+
+  let editing = false;
+  let editRouteId = null;
+  let editDraft = null;
+  let editOriginal = null;
+  let editMarkers = [];
+  let mapClickListener = null;
 
   function ensureDependencies() {
     return (
@@ -32,6 +47,88 @@
       typeof Utils !== "undefined" &&
       typeof turf !== "undefined"
     );
+  }
+
+  function cloneRoute(route) {
+    return {
+      id: route.id,
+      name: route.name,
+      color: route.color,
+      addresses: Array.isArray(route.addresses)
+        ? route.addresses.map((address) => String(address))
+        : [],
+      coordinates: Array.isArray(route.coordinates)
+        ? route.coordinates
+            .map((coord) =>
+              Array.isArray(coord) && coord.length === 2
+                ? [Number(coord[0]), Number(coord[1])]
+                : null
+            )
+            .filter(Boolean)
+        : [],
+    };
+  }
+
+  function routesAreEqual(a, b) {
+    if (!a || !b) return false;
+    if (a.coordinates.length !== b.coordinates.length) return false;
+    for (let i = 0; i < a.coordinates.length; i += 1) {
+      const [alat, alng] = a.coordinates[i];
+      const [blat, blng] = b.coordinates[i];
+      if (alat !== blat || alng !== blng) {
+        return false;
+      }
+    }
+    if (a.addresses.length !== b.addresses.length) return false;
+    for (let i = 0; i < a.addresses.length; i += 1) {
+      if (a.addresses[i] !== b.addresses[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function loadRoutes() {
+    const baseRoutes = Array.isArray(ROUTES) ? ROUTES.map(cloneRoute) : [];
+
+    let savedRoutes = [];
+    try {
+      const savedRaw = localStorage.getItem(STORAGE_KEY);
+      if (savedRaw) {
+        const parsed = JSON.parse(savedRaw);
+        if (Array.isArray(parsed)) {
+          savedRoutes = parsed
+            .map(cloneRoute)
+            .filter((route) => typeof route.id === "string");
+        }
+      }
+    } catch (error) {
+      console.warn("Unable to parse saved routes from localStorage.", error);
+    }
+
+    savedRoutes.forEach((saved) => {
+      const existingIndex = baseRoutes.findIndex((route) => route.id === saved.id);
+      if (existingIndex >= 0) {
+        baseRoutes[existingIndex] = saved;
+      } else {
+        baseRoutes.push(saved);
+      }
+    });
+
+    return baseRoutes;
+  }
+
+  function persistRoutes() {
+    try {
+      const serializable = routes.map(cloneRoute);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializable));
+    } catch (error) {
+      console.warn("Unable to save routes to localStorage.", error);
+    }
+  }
+
+  function getRouteById(routeId) {
+    return routes.find((route) => route.id === routeId) || null;
   }
 
   function initMap() {
@@ -46,16 +143,25 @@
     geocoder = new google.maps.Geocoder();
   }
 
+  function updateRouteSummary() {
+    if (!routeSummaryEl) return;
+    const totalStops = routes.reduce((count, route) => count + route.coordinates.length, 0);
+    routeSummaryEl.textContent = `${routes.length} routes · ${totalStops} stops`;
+  }
+
   function buildRouteResources() {
     allBounds = new google.maps.LatLngBounds();
+    routePolylines.clear();
+    routeBounds.clear();
+    routeLineStrings.clear();
 
-    ROUTES.forEach((route) => {
+    routes.forEach((route) => {
       const latLngs = Utils.toLatLngs(route.coordinates);
       const polyline = new google.maps.Polyline({
         map,
         path: latLngs,
         strokeColor: route.color,
-        strokeOpacity: 0.9,
+        strokeOpacity: 0.95,
         strokeWeight: 4,
         zIndex: 1,
       });
@@ -76,79 +182,91 @@
     }
   }
 
+  function refreshAllBounds() {
+    const combined = new google.maps.LatLngBounds();
+    routeBounds.forEach((bounds) => {
+      if (bounds && !bounds.isEmpty()) {
+        combined.union(bounds);
+      }
+    });
+    allBounds = combined;
+  }
+
+  function createRouteButton(route) {
+    const button = Utils.createEl("button", {
+      className: "route-item",
+      attrs: {
+        type: "button",
+        "data-route-id": route.id,
+        "aria-pressed": "false",
+        title: route.addresses.join("\n"),
+      },
+    });
+
+    const label = Utils.createEl("span", { className: "route-item__label" });
+    const swatch = Utils.createEl("span", { className: "route-item__swatch" });
+    swatch.style.backgroundColor = route.color;
+    const name = Utils.createEl("span", {
+      className: "route-item__name",
+      text: route.name,
+    });
+    label.appendChild(swatch);
+    label.appendChild(name);
+
+    const hint = Utils.createEl("span", {
+      className: "route-item__hint",
+      text: `${route.coordinates.length} stops`,
+    });
+
+    button.appendChild(label);
+    button.appendChild(hint);
+
+    button.addEventListener("click", () => handleRouteSelection(route.id));
+    button.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        button.click();
+      }
+    });
+
+    return button;
+  }
+
   function buildRouteList() {
     if (!routeListEl) return;
     routeListEl.innerHTML = "";
     routeButtons.clear();
 
-    ROUTES.forEach((route) => {
-      const button = Utils.createEl("button", {
-        className: "route-item",
-        attrs: {
-          type: "button",
-          "data-route-id": route.id,
-          "aria-pressed": "false",
-        },
-      });
-
-      const label = Utils.createEl("div", { className: "route-item__label" });
-      const swatch = Utils.createEl("span", {
-        className: "route-item__swatch",
-      });
-      swatch.style.background = route.color;
-      const name = Utils.createEl("span", {
-        className: "route-item__name",
-        text: route.name,
-      });
-      label.appendChild(swatch);
-      label.appendChild(name);
-
-      const hint = Utils.createEl("span", {
-        className: "route-item__hint",
-        text: "View",
-      });
-      hint.style.fontSize = "0.8rem";
-      hint.style.color = "var(--muted)";
-
-      button.appendChild(label);
-      button.appendChild(hint);
-
-      button.addEventListener("click", () => {
-        if (mode === "single" && selectedRouteId === route.id) {
-          showAllRoutes();
-        } else {
-          showSingleRoute(route.id);
-        }
-      });
-
-      button.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          button.click();
-        }
-      });
-
-      routeButtons.set(route.id, button);
+    routes.forEach((route) => {
+      const button = createRouteButton(route);
       routeListEl.appendChild(button);
+      routeButtons.set(route.id, button);
     });
+
+    updateRouteSummary();
+    updateRouteSelection(selectedRouteId);
   }
 
   function updateRouteSelection(routeId) {
     routeButtons.forEach((button, id) => {
       const isSelected = id === routeId;
-      button.setAttribute("aria-pressed", isSelected ? "true" : "false");
       button.classList.toggle("is-selected", isSelected);
+      button.setAttribute("aria-pressed", isSelected ? "true" : "false");
     });
   }
 
   function showAllRoutes() {
+    if (editing) return;
     mode = "all";
     selectedRouteId = null;
+
     routePolylines.forEach((polyline) => {
       polyline.setVisible(true);
       polyline.setOptions({ strokeWeight: 4, zIndex: 1 });
     });
+
     updateRouteSelection(null);
+
     if (allBounds && !allBounds.isEmpty()) {
       map.fitBounds(allBounds, 60);
     }
@@ -157,19 +275,22 @@
   function showSingleRoute(routeId) {
     mode = "single";
     selectedRouteId = routeId;
+
     routePolylines.forEach((polyline, id) => {
       const isSelected = id === routeId;
-      polyline.setVisible(isSelected);
+      polyline.setVisible(isSelected || editing);
       polyline.setOptions({
-        strokeWeight: isSelected ? 6 : 4,
-        zIndex: isSelected ? 3 : 1,
+        strokeWeight: isSelected ? 6 : 3,
+        zIndex: isSelected ? 4 : 1,
+        strokeOpacity: isSelected ? 1 : 0.35,
       });
     });
+
     updateRouteSelection(routeId);
 
     const bounds = routeBounds.get(routeId);
     if (bounds && !bounds.isEmpty()) {
-      map.fitBounds(bounds, 50);
+      map.fitBounds(bounds, 60);
     }
   }
 
@@ -189,24 +310,20 @@
         text: content,
       });
       resultsPanelEl.appendChild(message);
-      resultsTextEl = message;
       return;
     }
 
     if (content && typeof content === "object") {
       const { address, routeName, miles } = content;
       const message = Utils.createEl("p", { className: "result-text" });
-      const strong = Utils.createEl("strong", { text: routeName });
-      message.appendChild(strong);
-      message.appendChild(document.createTextNode(` is ${miles} miles away.`));
+      message.innerHTML = `<strong>${routeName}</strong> is ${miles} miles away.`;
       resultsPanelEl.appendChild(message);
-      resultsTextEl = message;
 
       if (address) {
         const meta = Utils.createEl("p", {
           className: "result-meta",
+          text: `Address: ${address}`,
         });
-        meta.textContent = `Address: ${address}`;
         resultsPanelEl.appendChild(meta);
       }
     }
@@ -228,7 +345,9 @@
     }
 
     resetResults();
-    showAllRoutes();
+    if (!editing) {
+      showAllRoutes();
+    }
     if (addressInputEl) {
       addressInputEl.value = "";
       addressInputEl.focus();
@@ -292,7 +411,7 @@
       const searchPoint = turf.point([location.lng(), location.lat()]);
       let closest = null;
 
-      ROUTES.forEach((route) => {
+      routes.forEach((route) => {
         const line = routeLineStrings.get(route.id);
         if (!line) return;
         const nearest = turf.nearestPointOnLine(line, searchPoint);
@@ -326,16 +445,269 @@
         address: result.formatted_address,
       });
 
-      if (mode !== "single" || selectedRouteId !== closest.route.id) {
+      if (!editing) {
         showSingleRoute(closest.route.id);
+        Utils.scrollToRoute(closest.route.id);
       }
-
-      Utils.scrollToRoute(closest.route.id);
     });
   }
 
+  function clearEditMarkers() {
+    editMarkers.forEach((markerInstance) => {
+      markerInstance.setMap(null);
+    });
+    editMarkers = [];
+  }
+
+  function updatePolylinePathFromDraft() {
+    if (!editRouteId || !editDraft) return;
+    const polyline = routePolylines.get(editRouteId);
+    if (polyline) {
+      polyline.setPath(Utils.toLatLngs(editDraft.coordinates));
+    }
+    routeLineStrings.set(editRouteId, Utils.toLineString(editDraft.coordinates));
+    const bounds = new google.maps.LatLngBounds();
+    editDraft.coordinates.forEach(([lat, lng]) => {
+      bounds.extend(new google.maps.LatLng(lat, lng));
+    });
+    routeBounds.set(editRouteId, bounds);
+    refreshAllBounds();
+  }
+
+  function renderDraftMarkers() {
+    clearEditMarkers();
+    if (!editing || !editDraft) return;
+
+    const route = getRouteById(editRouteId);
+    const color = route ? route.color : "#2563eb";
+
+    editDraft.coordinates.forEach(([lat, lng], index) => {
+      const markerInstance = new google.maps.Marker({
+        map,
+        position: { lat, lng },
+        draggable: true,
+        title: editDraft.addresses[index] || `Stop ${index + 1}`,
+        icon: {
+          path: google.maps.SymbolPath.CIRCLE,
+          scale: 8,
+          fillColor: color,
+          fillOpacity: 0.95,
+          strokeColor: "#ffffff",
+          strokeWeight: 2,
+        },
+        zIndex: 5,
+      });
+
+      markerInstance.addListener("dragend", (event) => {
+        editDraft.coordinates[index] = [event.latLng.lat(), event.latLng.lng()];
+        updatePolylinePathFromDraft();
+        updateEditButtons();
+      });
+
+      markerInstance.addListener("click", () => {
+        if (!editing) return;
+        const label = editDraft.addresses[index] || `Stop ${index + 1}`;
+        const confirmed = window.confirm(`Remove stop "${label}" from this route?`);
+        if (!confirmed) return;
+        editDraft.coordinates.splice(index, 1);
+        editDraft.addresses.splice(index, 1);
+        updatePolylinePathFromDraft();
+        renderDraftMarkers();
+        updateEditButtons();
+      });
+
+      editMarkers.push(markerInstance);
+    });
+  }
+
+  function isDraftDirty() {
+    if (!editing || !editDraft || !editOriginal) return false;
+    return !routesAreEqual(editDraft, editOriginal);
+  }
+
+  function startDraft(routeId) {
+    const route = getRouteById(routeId);
+    if (!route) return;
+    editRouteId = routeId;
+    editOriginal = cloneRoute(route);
+    editDraft = cloneRoute(route);
+    renderDraftMarkers();
+    updatePolylinePathFromDraft();
+    showSingleRoute(routeId);
+    updateEditButtons();
+  }
+
+  function enterEditMode() {
+    if (editing) return;
+    if (!routes.length) return;
+
+    editing = true;
+    document.body.classList.add("edit-mode");
+    editModeBtn.setAttribute("aria-pressed", "true");
+    editModeBtn.textContent = "Exit Edit Mode";
+    if (editPanelEl) {
+      editPanelEl.hidden = false;
+    }
+    if (showAllBtn) {
+      showAllBtn.disabled = true;
+    }
+
+    if (!selectedRouteId) {
+      selectedRouteId = routes[0].id;
+    }
+    startDraft(selectedRouteId);
+
+    if (!mapClickListener) {
+      mapClickListener = map.addListener("click", (event) => {
+        if (!editing || !editDraft) return;
+        const lat = event.latLng.lat();
+        const lng = event.latLng.lng();
+        const defaultLabel = `New stop (${lat.toFixed(5)}, ${lng.toFixed(5)})`;
+        const label = window.prompt("Label for the new stop:", defaultLabel) || defaultLabel;
+        editDraft.coordinates.push([lat, lng]);
+        editDraft.addresses.push(label.trim());
+        updatePolylinePathFromDraft();
+        renderDraftMarkers();
+        updateEditButtons();
+      });
+    }
+  }
+
+  function cleanupDraft(revertPolyline = false) {
+    if (revertPolyline && editRouteId && editOriginal) {
+      const polyline = routePolylines.get(editRouteId);
+      if (polyline) {
+        polyline.setPath(Utils.toLatLngs(editOriginal.coordinates));
+      }
+      const bounds = new google.maps.LatLngBounds();
+      editOriginal.coordinates.forEach(([lat, lng]) => {
+        bounds.extend(new google.maps.LatLng(lat, lng));
+      });
+      routeBounds.set(editRouteId, bounds);
+      routeLineStrings.set(editRouteId, Utils.toLineString(editOriginal.coordinates));
+      refreshAllBounds();
+    }
+    clearEditMarkers();
+    editDraft = null;
+    editOriginal = null;
+    editRouteId = null;
+    updateEditButtons();
+  }
+
+  function exitEditMode({ revert = true } = {}) {
+    if (!editing) return;
+
+    if (mapClickListener) {
+      google.maps.event.removeListener(mapClickListener);
+      mapClickListener = null;
+    }
+
+    cleanupDraft(revert);
+
+    editing = false;
+    document.body.classList.remove("edit-mode");
+    editModeBtn.setAttribute("aria-pressed", "false");
+    editModeBtn.textContent = "Edit Route";
+    if (editPanelEl) {
+      editPanelEl.hidden = true;
+    }
+    if (showAllBtn) {
+      showAllBtn.disabled = false;
+    }
+    if (saveRouteBtn) {
+      saveRouteBtn.disabled = true;
+    }
+
+    updateRouteSelection(selectedRouteId);
+    if (!selectedRouteId) {
+      showAllRoutes();
+    } else {
+      showSingleRoute(selectedRouteId);
+    }
+  }
+
+  function saveDraft() {
+    if (!editing || !editRouteId || !editDraft) return;
+    const route = getRouteById(editRouteId);
+    if (!route) return;
+
+    route.addresses = editDraft.addresses.map((address) => String(address));
+    route.coordinates = editDraft.coordinates.map(([lat, lng]) => [lat, lng]);
+
+    persistRoutes();
+    recalcRouteResources(editRouteId);
+    buildRouteList();
+    updateRouteSummary();
+    exitEditMode({ revert: false });
+  }
+
+  function recalcRouteResources(routeId) {
+    const route = getRouteById(routeId);
+    if (!route) return;
+
+    const latLngs = Utils.toLatLngs(route.coordinates);
+    const polyline = routePolylines.get(routeId);
+    if (polyline) {
+      polyline.setPath(latLngs);
+      polyline.setOptions({ strokeColor: route.color });
+    } else {
+      const newPolyline = new google.maps.Polyline({
+        map,
+        path: latLngs,
+        strokeColor: route.color,
+        strokeOpacity: 0.95,
+        strokeWeight: 4,
+        zIndex: 1,
+      });
+      routePolylines.set(routeId, newPolyline);
+    }
+
+    const bounds = new google.maps.LatLngBounds();
+    latLngs.forEach((latLng) => bounds.extend(latLng));
+    routeBounds.set(routeId, bounds);
+    routeLineStrings.set(routeId, Utils.toLineString(route.coordinates));
+    refreshAllBounds();
+
+    if (!bounds.isEmpty()) {
+      map.fitBounds(bounds, 60);
+    }
+  }
+
+  function handleRouteSelection(routeId) {
+    if (editing && editRouteId && routeId !== editRouteId) {
+      if (isDraftDirty()) {
+        const proceed = window.confirm(
+          "Discard unsaved changes and switch to another route?"
+        );
+        if (!proceed) {
+          return;
+        }
+      }
+      cleanupDraft(true);
+      startDraft(routeId);
+      return;
+    }
+
+    if (mode === "single" && selectedRouteId === routeId && !editing) {
+      showAllRoutes();
+    } else {
+      showSingleRoute(routeId);
+    }
+  }
+
+  function updateEditButtons() {
+    if (!saveRouteBtn) return;
+    saveRouteBtn.disabled = !editing || !isDraftDirty();
+  }
+
   function attachEventHandlers() {
-    const showAllBtn = document.getElementById("show-all");
+    showAllBtn = document.getElementById("show-all");
+    editModeBtn = document.getElementById("edit-route");
+    clearAddressBtn = document.getElementById("clear-address");
+    editPanelEl = document.getElementById("edit-panel");
+    saveRouteBtn = document.getElementById("save-route");
+    cancelEditBtn = document.getElementById("cancel-edit");
+
     if (showAllBtn) {
       showAllBtn.addEventListener("click", () => {
         showAllRoutes();
@@ -343,10 +715,43 @@
       });
     }
 
-    const clearBtn = document.getElementById("clear-address");
-    if (clearBtn) {
-      clearBtn.addEventListener("click", () => {
+    if (editModeBtn) {
+      editModeBtn.addEventListener("click", () => {
+        if (!editing) {
+          enterEditMode();
+        } else if (isDraftDirty()) {
+          const confirmExit = window.confirm(
+            "Discard unsaved changes and exit edit mode?"
+          );
+          if (!confirmExit) return;
+          exitEditMode({ revert: true });
+        } else {
+          exitEditMode({ revert: true });
+        }
+      });
+    }
+
+    if (clearAddressBtn) {
+      clearAddressBtn.addEventListener("click", () => {
         clearAddress();
+      });
+    }
+
+    if (saveRouteBtn) {
+      saveRouteBtn.addEventListener("click", () => {
+        saveDraft();
+      });
+    }
+
+    if (cancelEditBtn) {
+      cancelEditBtn.addEventListener("click", () => {
+        if (isDraftDirty()) {
+          const confirmed = window.confirm(
+            "Discard unsaved changes to this route?"
+          );
+          if (!confirmed) return;
+        }
+        exitEditMode({ revert: true });
       });
     }
 
@@ -366,47 +771,12 @@
         handleGeocode(value);
       });
     }
-
-    themeToggleEl = document.getElementById("theme-toggle");
-    if (themeToggleEl) {
-      const storedTheme = localStorage.getItem(THEME_KEY);
-      if (storedTheme === "dark") {
-        applyTheme("dark");
-      } else {
-        applyTheme("light");
-      }
-
-      themeToggleEl.addEventListener("click", () => {
-        const current = document.body.getAttribute("data-theme") === "dark" ? "dark" : "light";
-        const next = current === "dark" ? "light" : "dark";
-        applyTheme(next);
-        localStorage.setItem(THEME_KEY, next);
-      });
-    }
-  }
-
-  function applyTheme(theme) {
-    if (theme === "dark") {
-      document.body.setAttribute("data-theme", "dark");
-      if (themeToggleEl) {
-        themeToggleEl.setAttribute("aria-pressed", "true");
-        themeToggleEl.textContent = "Light theme";
-      }
-    } else {
-      document.body.removeAttribute("data-theme");
-      if (themeToggleEl) {
-        themeToggleEl.setAttribute("aria-pressed", "false");
-        themeToggleEl.textContent = "Dark theme";
-      }
-    }
   }
 
   function cacheElements() {
     routeListEl = document.getElementById("route-list");
     resultsPanelEl = document.getElementById("results-panel");
-    if (resultsPanelEl) {
-      resultsTextEl = resultsPanelEl.querySelector(".result-text");
-    }
+    routeSummaryEl = document.getElementById("route-summary");
   }
 
   function initializeApp() {
@@ -415,6 +785,8 @@
       setTimeout(initializeApp, 100);
       return;
     }
+
+    routes = loadRoutes();
 
     cacheElements();
     initMap();

--- a/js/routes.js
+++ b/js/routes.js
@@ -1,145 +1,201 @@
-const ROUTES = [
+export const ROUTES = [
   {
     id: "route-01",
-    name: "Route 01",
+    name: "Route 1",
     color: "#e6194b",
+    addresses: [
+      "16901 SE Division St, Portland 97236",
+      "9850 NE Everett St, Portland 97220",
+      "333 SE 127th Ave, Portland 97233",
+      "202 SE 188th Ave, Portland 97233",
+      "16810 SE Powell Blvd, Portland 97236"
+    ],
     coordinates: [
-      [30.3089, -97.9426],
-      [30.2967, -97.9052],
-      [30.2824, -97.8706],
-      [30.2671, -97.8397]
+      [45.5034, -122.4873],
+      [45.5269, -122.5611],
+      [45.5098, -122.529],
+      [45.5145, -122.4576],
+      [45.4977, -122.4893]
     ]
   },
   {
     id: "route-02",
-    name: "Route 02",
+    name: "Route 2",
     color: "#3cb44b",
-    coordinates: [
-      [30.3531, -97.7685],
-      [30.3394, -97.7413],
-      [30.3276, -97.7124],
-      [30.3129, -97.6845]
-    ]
+    addresses: ["777 NE 8th Ave, Gresham 97030"],
+    coordinates: [[45.4996, -122.4314]]
   },
   {
     id: "route-03",
-    name: "Route 03",
+    name: "Route 3",
     color: "#ffe119",
+    addresses: [
+      "203 SE 162nd Ave, Portland 97233",
+      "4405 NE 133rd Ave, Portland 97230",
+      "1757 SE 174th Ave, Portland 97233"
+    ],
     coordinates: [
-      [30.2692, -97.7606],
-      [30.2548, -97.7274],
-      [30.2363, -97.6995],
-      [30.2215, -97.6715]
+      [45.5071, -122.4997],
+      [45.553, -122.5265],
+      [45.5084, -122.482]
     ]
   },
   {
     id: "route-04",
-    name: "Route 04",
+    name: "Route 4",
     color: "#0082c8",
-    coordinates: [
-      [30.4176, -97.7398],
-      [30.3943, -97.7162],
-      [30.3741, -97.6907],
-      [30.3572, -97.6629]
-    ]
+    addresses: ["4515 W Powell Blvd, Gresham 97030"],
+    coordinates: [[45.4894, -122.4439]]
   },
   {
     id: "route-05",
-    name: "Route 05",
+    name: "Route 5",
     color: "#f58231",
+    addresses: [
+      "724 NE 195th Ave, Portland 97230",
+      "16920 SE Powell Blvd, Portland 97236",
+      "223 SE 182nd Ave, Portland 97233",
+      "15634 SE Division St, Portland 97236",
+      "16119 SE Division St, Portland 97236"
+    ],
     coordinates: [
-      [30.2971, -97.7902],
-      [30.2806, -97.7647],
-      [30.2648, -97.7395],
-      [30.2486, -97.7139]
+      [45.537, -122.474],
+      [45.495, -122.4863],
+      [45.5142, -122.4711],
+      [45.4984, -122.4989],
+      [45.4995, -122.493]
     ]
   },
   {
     id: "route-06",
-    name: "Route 06",
+    name: "Route 6",
     color: "#911eb4",
+    addresses: [
+      "16977 NE Halsey St, Portland 97230",
+      "660 SE 212th Ave, Gresham 97030",
+      "333 NE 181st Ave, Gresham 97030",
+      "19625 NE Glisan St, Portland 97230"
+    ],
     coordinates: [
-      [30.3928, -97.8567],
-      [30.3743, -97.8251],
-      [30.3569, -97.7942],
-      [30.3412, -97.7608]
+      [45.5338, -122.4765],
+      [45.5089, -122.4221],
+      [45.5271, -122.463],
+      [45.5278, -122.4508]
     ]
   },
   {
     id: "route-07",
-    name: "Route 07",
+    name: "Route 7",
     color: "#46f0f0",
-    coordinates: [
-      [30.2489, -97.8883],
-      [30.2296, -97.8548],
-      [30.2117, -97.8207],
-      [30.1951, -97.7856]
-    ]
+    addresses: ["777 NE 8th Ave, Gresham 97030"],
+    coordinates: [[45.4996, -122.4314]]
   },
   {
     id: "route-08",
-    name: "Route 08",
+    name: "Route 8",
     color: "#f032e6",
+    addresses: [
+      "930 SE 212th Ave, Gresham 97030",
+      "17366 NE Halsey St, Portland 97230",
+      "15848 SE Division St, Portland 97236",
+      "18737 SE Stark St, Portland 97233"
+    ],
     coordinates: [
-      [30.3314, -97.6282],
-      [30.3152, -97.6018],
-      [30.3004, -97.5742],
-      [30.2858, -97.5484]
+      [45.5014, -122.4205],
+      [45.5345, -122.4928],
+      [45.4988, -122.4992],
+      [45.5164, -122.4603]
     ]
   },
   {
     id: "route-09",
-    name: "Route 09",
+    name: "Route 9",
     color: "#d2f53c",
+    addresses: [
+      "16745 SE Division St, Portland 97236",
+      "100 NE 188th Ave, Portland 97230",
+      "128 NE 182nd Ave, Portland 97230"
+    ],
     coordinates: [
-      [30.4473, -97.8335],
-      [30.4278, -97.8014],
-      [30.4094, -97.7705],
-      [30.3891, -97.7393]
+      [45.4979, -122.4923],
+      [45.524, -122.4698],
+      [45.5233, -122.4716]
     ]
   },
   {
     id: "route-10",
     name: "Route 10",
     color: "#fabebe",
+    addresses: [
+      "2711 W Powell Blvd, Gresham 97030",
+      "1999 NE Division St, Gresham 97030",
+      "1555 NE Division St, Gresham 97030",
+      "1838 E Powell Blvd, Gresham 97030",
+      "1505 W Powell Blvd, Gresham 97030"
+    ],
     coordinates: [
-      [30.2129, -97.7074],
-      [30.1996, -97.6776],
-      [30.1854, -97.6455],
-      [30.1709, -97.6146]
+      [45.4909, -122.4224],
+      [45.4998, -122.4142],
+      [45.4994, -122.4172],
+      [45.4979, -122.4164],
+      [45.4996, -122.4191]
     ]
   },
   {
     id: "route-11",
     name: "Route 11",
     color: "#008080",
+    addresses: [
+      "765 Mt Hood Hwy, Gresham 97080",
+      "1212 NE Linden Ave, Gresham 97030",
+      "1951 NE Cleveland Ave, Gresham 97030",
+      "1500 NE Cleveland Ave, Gresham 97030",
+      "1001 NE Division St, Gresham 97030"
+    ],
     coordinates: [
-      [30.3786, -97.6912],
-      [30.3584, -97.6647],
-      [30.3398, -97.6375],
-      [30.3202, -97.6098]
+      [45.489, -122.4391],
+      [45.5059, -122.4387],
+      [45.5094, -122.4359],
+      [45.5048, -122.4352],
+      [45.5021, -122.4389]
     ]
   },
   {
     id: "route-12",
     name: "Route 12",
     color: "#e6beff",
+    addresses: [
+      "2629 SE 136th Ave, Portland 97236",
+      "4751 NE 99th Ave, Portland 97220",
+      "2144 SE 139th Ave, Portland 97233",
+      "2434 SE 139th Ave, Portland 97233",
+      "2602 SE 139th Ave, Portland 97233",
+      "2801 SE 139th Ave, Portland 97233"
+    ],
     coordinates: [
-      [30.2682, -97.6461],
-      [30.2514, -97.6164],
-      [30.2349, -97.5863],
-      [30.2187, -97.5569]
+      [45.4995, -122.5208],
+      [45.5535, -122.5564],
+      [45.5051, -122.5185],
+      [45.5065, -122.5192],
+      [45.5078, -122.52],
+      [45.5095, -122.5208]
     ]
   },
   {
     id: "route-13",
     name: "Route 13",
     color: "#aa6e28",
+    addresses: [
+      "937 NE Hood Ave, Gresham 97030",
+      "1280 NE Kane Dr, Gresham 97030",
+      "1420 NE Kane Dr, Gresham 97030",
+      "1830 NE Kane Dr, Gresham 97030"
+    ],
     coordinates: [
-      [30.4047, -97.9294],
-      [30.3862, -97.8936],
-      [30.3679, -97.8582],
-      [30.3488, -97.8231]
+      [45.5019, -122.4315],
+      [45.506, -122.4284],
+      [45.5073, -122.4272],
+      [45.5095, -122.4243]
     ]
   }
 ];

--- a/js/utils.js
+++ b/js/utils.js
@@ -5,8 +5,13 @@ const Utils = (() => {
   }
 
   function toLineString(coords) {
-    if (!Array.isArray(coords)) return turf.lineString([]);
+    if (!Array.isArray(coords) || coords.length === 0) {
+      return turf.lineString([]);
+    }
     const turfCoords = coords.map(([lat, lng]) => [lng, lat]);
+    if (turfCoords.length === 1) {
+      turfCoords.push([...turfCoords[0]]);
+    }
     return turf.lineString(turfCoords);
   }
 


### PR DESCRIPTION
## Summary
- preload the thirteen SnowCap routes with color-coded list entries and modern two-pane layout with logo placements
- add an edit mode that lets users drag, add, and remove route stops with localStorage persistence and safe cancellation
- refresh styling and documentation to match the new UX and GitHub Pages deployment flow

## Testing
- node --check js/app.js
- node --check js/utils.js

------
https://chatgpt.com/codex/tasks/task_e_68e56686472c833092800b75f7b75d6b