### PR TITLE
Center lock screen logo

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -122,7 +122,7 @@ button {
 
 #lock .app-logo {
   max-width: 200px;
-  margin-bottom: 20px;
+  margin: 0 auto 20px;
 }
 
 .lock-title {


### PR DESCRIPTION
## Summary
- center the logo on the password lock screen by applying automatic horizontal margins

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59eb4f764833093777abf37fd6cdb