### PR TITLE
Add client-side caching for Google Maps routes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -272,6 +272,15 @@ button {
   min-height: 0;
 }
 
+#cache-status {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  margin-top: auto;
+  padding: var(--space-sm) 0;
+  border-top: 1px solid var(--color-border);
+}
+
 .route-item {
   border-radius: var(--radius-md);
   background: var(--color-surface-elevated);

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
           </form>
           <p id="distance-result" class="distance-result" role="status" aria-live="polite"></p>
         </section>
+        <div id="cache-status" aria-live="polite">Cached Routes: 0/13</div>
       </aside>
       <main class="map-wrapper" role="application" aria-label="Route map">
         <div id="map" class="map" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add localStorage-based caching for each route with 30-day expiration and skip API calls when cached
- rehydrate cached Google Maps responses, persist used stops, and increase throttling delay for fresh requests
- add a cache status indicator in the sidebar with corresponding styling updates

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e59fc5819483308a5235cbb1f31380