### PR TITLE
Remove spring seasonal decorations and switch lock-screen to Summer update

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -277,94 +277,31 @@ button {
   overflow: hidden;
 }
 
-.spring-message {
+.season-message {
   position: absolute;
   top: 6vh;
   left: 50%;
   transform: translateX(-50%);
-  max-width: min(860px, 92vw);
+  max-width: min(640px, 92vw);
   margin: 0;
   text-align: center;
   font-weight: 700;
-  font-size: 1.1em;
+  font-size: 1.25em;
+  text-transform: uppercase;
   letter-spacing: 0.01em;
-  color: #ffd9f2;
+  color: #ffe8a3;
   text-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
-  animation: spring-pulse 2.8s ease-in-out infinite;
+  animation: season-pulse 2.8s ease-in-out infinite;
 }
 
-@keyframes spring-pulse {
+@keyframes season-pulse {
   0%,
   100% {
     transform: translateX(-50%) scale(1);
   }
   50% {
-    transform: translateX(-50%) scale(1.2);
+    transform: translateX(-50%) scale(1.08);
   }
-}
-
-.lock-bunny-row {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0.9rem;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  align-items: end;
-  justify-items: center;
-  padding: 0 clamp(0.7rem, 3.2vw, 2.25rem);
-  z-index: 6;
-  pointer-events: none;
-}
-
-.lock-bunny {
-  width: clamp(56px, 8vw, 104px);
-  animation: bunny-hop 1.4s cubic-bezier(0.34, 0.04, 0.18, 0.98) infinite;
-  transform-origin: center bottom;
-  will-change: transform;
-}
-
-.lock-bunny:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.lock-bunny:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes bunny-hop {
-  0% {
-    transform: translateX(40px) translateY(0) scaleX(-1);
-  }
-  22% {
-    transform: translateX(20px) translateY(-34px) scaleX(-1);
-  }
-  50% {
-    transform: translateX(0) translateY(0) scaleX(-1);
-  }
-  74% {
-    transform: translateX(-20px) translateY(-38px) scaleX(-1);
-  }
-  100% {
-    transform: translateX(-40px) translateY(0) scaleX(-1);
-  }
-}
-
-.spring-map-deco {
-  width: 36px;
-  height: 36px;
-  object-fit: contain;
-  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.45));
-  user-select: none;
-}
-
-.easter-egg-marker {
-  width: 34px;
-  height: 34px;
-  object-fit: contain;
-  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.45));
-  user-select: none;
-  cursor: pointer;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -12,14 +12,7 @@
     </noscript>
 
     <div id="lock" class="lock-screen" role="dialog" aria-modal="true" aria-labelledby="lock-title">
-      <p class="spring-message" aria-live="polite">
-        Spring Has Sprung! Please enjoy the Spring update to the Snowcap Route Mapper, we (Garreth) worked really hard to add them! Have a great time!
-      </p>
-      <div class="lock-bunny-row" aria-hidden="true">
-        <img src="./assets/bunny1.png" alt="" class="lock-bunny" />
-        <img src="./assets/bunny1.png" alt="" class="lock-bunny" />
-        <img src="./assets/bunny1.png" alt="" class="lock-bunny" />
-      </div>
+      <p class="season-message" aria-live="polite">Summer update!</p>
       <div class="lock-card">
         <img src="./assets/snowcapmain.png" alt="SnowCap logo" class="app-logo" />
         <h1 id="lock-title" class="lock-title">Welcome to SnowCap Route Mapper</h1>

--- a/js/app.js
+++ b/js/app.js
@@ -6,11 +6,6 @@
   const LIGHT = "light";
   const HIGHLIGHT_DURATION = 2600;
   const HOUSE_ADDRESS = "17805 SE Stark St.\nPortland, OR 97233";
-  const SPRING_DECORATION_ASSETS = ["tulip1", "tulip2", "flower1", "poppy1", "lily1"];
-  const SPRING_DECORATION_COUNT = 34;
-  const EASTER_EGG_COUNT = 1;
-  const DECORATION_ROUTE_BUFFER_MILES = 0.25;
-  const EASTER_EGG_MESSAGE = "You found an easter egg! I couldn't figure out a reward so I will wish you a happy day";
 
   const mapStyles = {
     dark: [
@@ -81,8 +76,6 @@
   let closestRouteMatches = [];
   let activeClosestRouteIndex = -1;
   let activeDistanceLocation = null;
-  const springMarkers = [];
-  const easterEggMarkers = [];
 
   function $(selector) {
     return document.querySelector(selector);
@@ -795,111 +788,6 @@
     return marker;
   }
 
-  function randomInRange(min, max) {
-    return min + Math.random() * (max - min);
-  }
-
-  function getBoundsPoint(bounds) {
-    const northEast = bounds.getNorthEast();
-    const southWest = bounds.getSouthWest();
-    const lat = randomInRange(southWest.lat(), northEast.lat());
-    const lng = randomInRange(southWest.lng(), northEast.lng());
-    return { lat, lng };
-  }
-  function isPointNearRouteLine(position, routeLines, minDistanceMiles) {
-    if (!position || !Array.isArray(routeLines) || !routeLines.length || typeof turf === "undefined") {
-      return false;
-    }
-    if (typeof turf.point !== "function" || typeof turf.pointToLineDistance !== "function") {
-      return false;
-    }
-
-    const point = turf.point([position.lng, position.lat]);
-    return routeLines.some((line) => {
-      if (!line) return false;
-      const distance = turf.pointToLineDistance(point, line, { units: "miles" });
-      return Number.isFinite(distance) && distance < minDistanceMiles;
-    });
-  }
-
-  function getValidDecorationPoint(bounds, routeLines, minDistanceMiles) {
-    const maxAttempts = 80;
-    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-      const candidate = getBoundsPoint(bounds);
-      if (!isPointNearRouteLine(candidate, routeLines, minDistanceMiles)) {
-        return candidate;
-      }
-    }
-    return getBoundsPoint(bounds);
-  }
-
-  function buildAlternatingDecorationList(totalCount) {
-    const icons = [];
-    let previous = null;
-    for (let i = 0; i < totalCount; i += 1) {
-      const candidates = SPRING_DECORATION_ASSETS.filter((name) => name !== previous);
-      const next = candidates[Math.floor(Math.random() * candidates.length)] || SPRING_DECORATION_ASSETS[0];
-      icons.push(next);
-      previous = next;
-    }
-    return icons;
-  }
-
-  function clearSeasonalMarkers(markers) {
-    markers.forEach((marker) => marker.setMap(null));
-    markers.length = 0;
-  }
-
-  function addSpringDecorations() {
-    if (!map || !overallBounds) return;
-    clearSeasonalMarkers(springMarkers);
-
-    const routeLines = Array.from(routeData.values())
-      .map((entry) => entry.turfLine)
-      .filter(Boolean);
-    const iconList = buildAlternatingDecorationList(SPRING_DECORATION_COUNT);
-
-    iconList.forEach((iconName) => {
-      const marker = new google.maps.Marker({
-        position: getValidDecorationPoint(overallBounds, routeLines, DECORATION_ROUTE_BUFFER_MILES),
-        map,
-        icon: {
-          url: `./assets/${iconName}.png`,
-          scaledSize: new google.maps.Size(34, 34)
-        },
-        clickable: false,
-        optimized: true,
-        zIndex: 40
-      });
-      springMarkers.push(marker);
-    });
-  }
-
-  function addEasterEggMarkers() {
-    if (!map || !overallBounds) return;
-    clearSeasonalMarkers(easterEggMarkers);
-
-    const routeLines = Array.from(routeData.values())
-      .map((entry) => entry.turfLine)
-      .filter(Boolean);
-
-    for (let i = 0; i < EASTER_EGG_COUNT; i += 1) {
-      const marker = new google.maps.Marker({
-        position: getValidDecorationPoint(overallBounds, routeLines, DECORATION_ROUTE_BUFFER_MILES),
-        map,
-        icon: {
-          url: "./assets/easteregg1.png",
-          scaledSize: new google.maps.Size(36, 36)
-        },
-        title: "Easter egg",
-        zIndex: 80
-      });
-      marker.addListener("click", () => {
-        window.alert(EASTER_EGG_MESSAGE);
-      });
-      easterEggMarkers.push(marker);
-    }
-  }
 
   async function geocodeAddress(address) {
     if (!geocoder) {
@@ -1150,8 +1038,6 @@
       await renderRoute(route);
     }
 
-    addSpringDecorations();
-    addEasterEggMarkers();
 
     console.log("✅ Dynamic routing restored with legend, highlight, label, and smooth zoom features active");
 
@@ -1342,13 +1228,10 @@
       piece.style.position = "fixed";
       piece.style.left = `${rect.left + rect.width / 2 + (Math.random() * 220 - 110)}px`;
       piece.style.top = `${Math.max(rect.top - 20, 0)}px`;
-      piece.style.background = "transparent";
-      piece.style.backgroundImage = "url('./assets/easteregg1.png')";
-      piece.style.backgroundSize = "cover";
-      piece.style.backgroundPosition = "center";
+      piece.style.background = `hsl(${Math.floor(Math.random() * 60) + 20} 95% 60%)`;
       piece.style.width = `${16 + Math.random() * 10}px`;
       piece.style.height = `${16 + Math.random() * 10}px`;
-      piece.style.borderRadius = "0";
+      piece.style.borderRadius = "999px";
       piece.style.animationDelay = `${Math.random() * 0.2}s`;
       piece.style.animationDuration = `${2.6 + Math.random() * 1.6}s`;
       piece.style.setProperty("--drift", String(Math.random()));


### PR DESCRIPTION
### Motivation
- Remove seasonal spring/easter decorations and messaging so the app no longer shows eggs, flowers, bunnies, or spring-specific UI when not desired.
- Replace the seasonal lock-screen copy with a neutral summer announcement to reflect the new update.
- Simplify UI effects by removing dependencies on spring assets and avoid adding seasonal markers to the map.

### Description
- Replaced the lock-screen banner and removed the bunny row in `index.html`, changing the copy to `Summer update!` and using the `.season-message` class.
- Renamed and restyled the spring message CSS to `.season-message` in `css/styles.css` and removed spring/bunny/easter-specific style blocks and animations.
- Removed spring/easter-related constants, decoration marker arrays, helper functions, and initialization calls from `js/app.js` so no seasonal markers are placed on the map anymore.
- Updated `launchEdithConfetti` in `js/app.js` to render bright summer-colored circular pieces instead of using the easter egg image asset.

### Testing
- Ran `node --check js/app.js` which completed without syntax errors (success).
- Searched the codebase with `rg -n "spring|easter|bunny|tulip|flower|poppy|lily|egg" index.html js/app.js css/styles.css` to validate removal of spring/easter references (successful scan showing intended removals).
- Verified the modified files `index.html`, `css/styles.css`, and `js/app.js` pass static checks performed in the environment (no automated test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d971cbee28833092c0179161a08819)